### PR TITLE
Check for None in select function for PyComponent

### DIFF
--- a/panel/custom.py
+++ b/panel/custom.py
@@ -159,6 +159,8 @@ class PyComponent(Viewable, Layoutable):
     def select(
         self, selector: type | Callable[[Viewable], bool] | None = None
     ) -> list[Viewable]:
+        if self._view__ is None:
+            self._view__ = self._create__view()
         return super().select(selector) + self._view__.select(selector)
 
 


### PR DESCRIPTION
Call the `_create__view` function when ```_view__``` is None, to avoid the error 'NoneType' object has no attribute 'select'
Fix #7835