### PR TITLE
Serve index.html when serving static directory

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -902,7 +902,7 @@ def get_static_routes(static_dirs):
         if not os.path.isdir(path):
             raise ValueError(f"Cannot serve non-existent path {path}")
         patterns.append(
-            (rf"{slug}/(.*)", AuthenticatedStaticFileHandler, {"path": path})
+            (rf"{slug}/(.*)", AuthenticatedStaticFileHandler, {"path": path, "default_filename": "index.html"})
         )
     patterns.append((
         f'/{COMPONENT_PATH}(.*)', ComponentResourceHandler, {}


### PR DESCRIPTION
From the example described in [Serving static files](https://panel.holoviz.org/how_to/server/static_files.html), when user go to `http://localhost:5006/assets/` it will serve the index.html file inside the folder. Otherwise only the address`http://localhost:5006/assets/index.html` is valid 